### PR TITLE
Machine endpoints

### DIFF
--- a/database.go
+++ b/database.go
@@ -30,7 +30,7 @@ import (
 	"text/template"
 	"time"
 
-	"gopkg.in/gorilla/mux.v1"
+	"github.com/gorilla/mux"
 )
 
 type SSHPorts struct {

--- a/database.go
+++ b/database.go
@@ -20,29 +20,95 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"text/template"
 	"time"
+
+	"gopkg.in/gorilla/mux.v1"
 )
 
+type SSHPorts struct {
+	Installer int `json:"installer,omitempty"`
+}
+
 type Machine struct {
-	Name         string `json:"name,omitempty"`
-	UUID         string `json:"uuid"`
-	SerialNumber string `json:"serialNumber,omitempty"`
-	AssetTag     string `json:"assetTag,omitempty"`
-	Type         string `json:"type"`
-	ManagerName  string `json:"-"`
-	ManagedBy    string `json:"managedBy"`
+	Name          string   `json:"name,omitempty"`
+	UUID          string   `json:"uuid"`
+	SerialNumber  string   `json:"serialNumber,omitempty"`
+	AssetTag      string   `json:"assetTag,omitempty"`
+	Type          string   `json:"type"`
+	ManagerName   string   `json:"-"`
+	ManagedBy     string   `json:"managedBy"`
+	SshPorts      SSHPorts `json:"sshPorts",omitempty"`
+	InstallerAddr string   `json:"installerAddress,omitempty"`
+
+	installRequest *InstallRequest
+}
+
+func (m *Machine) State() string {
+	if m.installRequest == nil {
+		return "provisioned"
+	}
+
+	if m.installRequest.State == "" {
+		return "unknown"
+	}
+	return m.installRequest.State
+}
+
+// When calling this function, you should hold a read-lock on the db object
+func (m *Machine) getInstallRequest(db *tateruDb) {
+	installRequest, ok := db.installRequests[m.UUID]
+	if ok {
+		m.installRequest = &installRequest
+
+		// TODO: implement a custom JSON encoder instead of manually duplicating attributes
+		m.InstallerAddr = installRequest.InstallerAddr
+		m.SshPorts = installRequest.SshPorts
+	}
+}
+
+type InstallRequest struct {
+	LastUpdate    time.Time
+	Nonce         string
+	State         string
+	SshPubKey     string
+	InstallerAddr string
+	SshPorts      SSHPorts
+}
+
+type BootInstallerRequest struct {
+	Nonce     string `json:"nonce"`
+	SshPubKey string `json:"ssh_pub_key"`
+}
+
+type ManagerBootInstallerRequest struct {
+	Nonce string `json:"nonce"`
+}
+
+type CallbackRequest struct {
+	// Why are Serial Number and AssetTag included here?
+	// Should we abort if they do not match what is set on the Machine (via the manager)?
+	SerialNumber string   `json:"serialNumber,omitempty"`
+	AssetTag     string   `json:"assetTag,omitempty"`
+	SshPorts     SSHPorts `json:"sshPorts,omitempty"`
+}
+
+type CallbackResponse struct {
+	SshPubKey string `json:"ssh_pub_key"`
 }
 
 type tateruDb struct {
-	machinesMutex sync.RWMutex
-	machines      []Machine
-	indexTmpl     *template.Template
+	machinesMutex   sync.RWMutex
+	machines        []Machine
+	installRequests map[string]InstallRequest
+	indexTmpl       *template.Template
 }
 
 func (db *tateruDb) HandleIndex(w http.ResponseWriter, r *http.Request) {
@@ -115,6 +181,9 @@ func (db *tateruDb) Poll() {
 		db.machinesMutex.Lock()
 		db.machines = machs
 		db.machinesMutex.Unlock()
+
+		// TODO: expire old install requests?
+
 		time.Sleep(time.Second * 30)
 	}
 }
@@ -137,6 +206,178 @@ func (db *tateruDb) HandleMachinesAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	db.machinesMutex.RUnlock()
+
+func (db *tateruDb) HandleFetchMachineAPI(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	uuid := vars["uuid"]
+
+	db.machinesMutex.RLock()
+	defer db.machinesMutex.RUnlock()
+
+	var machine *Machine
+	for _, m := range db.machines {
+		if m.UUID == uuid {
+			machine = &m
+		}
+	}
+
+	if machine == nil {
+		http.Error(w, "No machine with this UUID found", http.StatusNotFound)
+		return
+	}
+
+	b, err := json.MarshalIndent(machine, "", " ")
+	if err != nil {
+		http.Error(w, "Failed to render JSON", http.StatusInternalServerError)
+		log.Printf("Failed to marshal machine JSON: %v", err)
+		return
+	}
+
+	w.Header().Add("content-type", "application/json; charset=utf-8")
+	w.Write(b)
+	return
+}
+
+func (db *tateruDb) HandleBootInstallerAPI(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	uuid := vars["uuid"]
+
+	db.machinesMutex.Lock()
+	defer db.machinesMutex.Unlock()
+
+	machine := Machine{}
+	for _, m := range db.machines {
+		if m.UUID == uuid {
+			machine = m
+		}
+	}
+	if machine.UUID != uuid {
+		http.Error(w, "No machine with this UUID found", http.StatusNotFound)
+		return
+	}
+
+	// Parse payload
+	var bir BootInstallerRequest
+	err := json.NewDecoder(r.Body).Decode(&bir)
+	if err != nil {
+		http.Error(w, "Unable to parse request body as BootInstallerRequest", http.StatusUnprocessableEntity)
+		log.Printf("Unable to parse request body as BootInstallerRequest: %v", err)
+		return
+	}
+
+	installRequest := InstallRequest{
+		LastUpdate: time.Now(),
+		State:      "pending",
+		SshPubKey:  bir.SshPubKey,
+		Nonce:      bir.Nonce,
+	}
+	db.installRequests[uuid] = installRequest
+
+	// Send boot-installer request to manager for machine
+	managerBir := ManagerBootInstallerRequest{
+		Nonce: bir.Nonce,
+	}
+	b, err := json.MarshalIndent(managerBir, "", " ")
+	if err != nil {
+		http.Error(w, "Failed to generate BootInstallerRequest for manager", http.StatusInternalServerError)
+		log.Printf("Failed to marshal ManagerBootInstallRequest JSON: %v", err)
+		return
+	}
+
+	client := &http.Client{}
+	bootInstallerURL := fmt.Sprintf("%s/v1/machines/%s/boot-installer", machine.ManagedBy, machine.UUID)
+	resp, err := client.Post(bootInstallerURL, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		http.Error(w, "Error when sending boot-installer request to manager", http.StatusInternalServerError)
+		log.Printf("Error when sending boot-installer request to manager: %v", err)
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		http.Error(w, "Manager could not successfully process boot-installer request", http.StatusInternalServerError)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Manager replied with '%s' to boot-installer request. Error reading response: %s", resp.Status, err)
+		} else {
+			log.Printf("Manager replied with '%s' to boot-installer request: %s", resp.Status, body)
+		}
+		return
+	}
+
+	installRequest.LastUpdate = time.Now()
+	installRequest.State = "booting"
+	db.installRequests[uuid] = installRequest
+
+	return
+}
+
+func (db *tateruDb) HandleInstallerCallbackAPI(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	uuid := vars["uuid"]
+
+	db.machinesMutex.Lock()
+	defer db.machinesMutex.Unlock()
+
+	machine := Machine{}
+	for _, m := range db.machines {
+		if m.UUID == uuid {
+			machine = m
+		}
+	}
+	if machine.UUID != uuid {
+		http.Error(w, "No machine with this UUID found", http.StatusNotFound)
+		return
+	}
+
+	installRequest, ok := db.installRequests[uuid]
+	if !ok {
+		http.Error(w, "No install request found for this machine", http.StatusNotFound)
+		log.Printf("Received installer callback for machine '%s', but there was previous InstallerRequest", machine.UUID)
+		return
+	}
+
+	// Parse payload
+	var cr CallbackRequest
+	err := json.NewDecoder(r.Body).Decode(&cr)
+	if err != nil {
+		http.Error(w, "Unable to parse request body as CallbackRequest", http.StatusUnprocessableEntity)
+		log.Printf("Unable to parse request body as CallbackRequest: %v", err)
+		return
+	}
+
+	// Update machine with information
+	installerAddr := r.Header.Get("X-Forwarded-For")
+	if installerAddr == "" {
+		installerAddr = r.RemoteAddr
+		if strings.HasPrefix(installerAddr, "[") {
+			parts := strings.SplitN(installerAddr, "]:", 2)
+			installerAddr = strings.Trim(parts[0], "[")
+		} else {
+			parts := strings.SplitN(installerAddr, ":", 2)
+			installerAddr = parts[0]
+		}
+	}
+	installRequest.InstallerAddr = installerAddr
+	installRequest.SshPorts = cr.SshPorts
+
+	cresp := CallbackResponse{
+		SshPubKey: installRequest.SshPubKey,
+	}
+	b, err := json.MarshalIndent(cresp, "", " ")
+	if err != nil {
+		http.Error(w, "Failed to render JSON", http.StatusInternalServerError)
+		log.Printf("Failed to marshal CallbackResponse JSON: %v", err)
+		return
+	}
+
+	installRequest.LastUpdate = time.Now()
+	installRequest.State = "booted"
+	db.installRequests[uuid] = installRequest
+
+	w.Header().Add("content-type", "application/json; charset=utf-8")
 	w.Write(b)
 	return
 }

--- a/database.go
+++ b/database.go
@@ -118,7 +118,13 @@ func (db *tateruDb) HandleIndex(w http.ResponseWriter, r *http.Request) {
 		Machines []Machine
 	}
 	db.machinesMutex.RLock()
-	d.Machines = db.machines
+
+	machs := []Machine{}
+	for _, m := range db.machines {
+		m.getInstallRequest(db)
+		machs = append(machs, m)
+	}
+	d.Machines = machs
 
 	b := &bytes.Buffer{}
 	if err := db.indexTmpl.Execute(b, d); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 require (
 	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.8.0
 	gopkg.in/gorilla/handlers.v1 v1.4.0
 	gopkg.in/gorilla/mux.v1 v1.6.2
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/tateru/tateru-machine-service
 
 go 1.16
 
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	github.com/gorilla/context v1.1.1 // indirect
+	gopkg.in/gorilla/handlers.v1 v1.4.0
+	gopkg.in/gorilla/mux.v1 v1.6.2
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/golang-lru v0.5.4
 	gopkg.in/gorilla/handlers.v1 v1.4.0
 	gopkg.in/gorilla/mux.v1 v1.6.2
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/gorilla/handlers.v1 v1.4.0 h1:dD+J4RGXwT7R17TX4hqDCoGMIKDbapDJENUwAgyTZow=
+gopkg.in/gorilla/handlers.v1 v1.4.0/go.mod h1:o7WIirxsm7EPn28G+NWxv3L0Y7mue08OdaxiocakJz8=
+gopkg.in/gorilla/mux.v1 v1.6.2 h1:tqLaxQbXrLoJ8s8TxRt8h0Cy8tC6hoZYPUh6XEydXdQ=
+gopkg.in/gorilla/mux.v1 v1.6.2/go.mod h1:e2OVw+7KJ9sr6MyI5tOf+k3H6vtMSI2/AnbzLAWuwRw=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gorilla/handlers.v1 v1.4.0 h1:dD+J4RGXwT7R17TX4hqDCoGMIKDbapDJENUwAgyTZow=
 gopkg.in/gorilla/handlers.v1 v1.4.0/go.mod h1:o7WIirxsm7EPn28G+NWxv3L0Y7mue08OdaxiocakJz8=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gorilla/handlers.v1 v1.4.0 h1:dD+J4RGXwT7R17TX4hqDCoGMIKDbapDJENUwAgyTZow=
 gopkg.in/gorilla/handlers.v1 v1.4.0/go.mod h1:o7WIirxsm7EPn28G+NWxv3L0Y7mue08OdaxiocakJz8=

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ import (
 	"net/http"
 	"os"
 
-	"gopkg.in/gorilla/handlers.v1"
-	"gopkg.in/gorilla/mux.v1"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v2"
 )
 

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	if err := yaml.Unmarshal([]byte(cfile), &cfg); err != nil {
 		log.Fatalf("yaml.Unmarshal failed: %v", err)
 	}
-	db := &tateruDb{indexTmpl: indexTmpl, installRequests: make(map[string]InstallRequest)}
+	db := &tateruDB{indexTmpl: indexTmpl, installRequests: make(map[string]InstallRequest)}
 	go db.Poll()
 	router := mux.NewRouter()
 	rf, _ := fs.Sub(resources, "resources")

--- a/resources/index.html
+++ b/resources/index.html
@@ -37,6 +37,16 @@ $(document).ready(function(){
 .icon img {
   width: 100%;
 }
+
+tr[data-installer-state=pending] {
+  background-color: #cff4fc;
+}
+tr[data-installer-state=booting] {
+  background-color: #cfe2ff;
+}
+tr[data-installer-state=booted] {
+  background-color: #d1e7dd;
+}
 </style>
 </head>
 <body>
@@ -57,7 +67,7 @@ $(document).ready(function(){
   </tr></thead>
   <tbody>
 {{ range $m := .Machines }}
-    <tr>
+    <tr data-installer-state="{{ $m.State }}">
       <td class="single line">
         <div class="ui accordion">
           <div class="title">

--- a/state_machine.go
+++ b/state_machine.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"sync"
+)
+
+type EventName string
+
+type Event struct {
+	NewState StateName
+}
+
+type EventMap map[EventName]Event
+
+type StateName string
+
+type State struct {
+	Events EventMap
+}
+
+type StateMap map[StateName]State
+
+type StateMachine struct {
+	InitialState StateName
+	States       StateMap
+
+	current StateName
+	cond    *sync.Cond
+}
+
+func NewStateMachine(initialState StateName, states StateMap) *StateMachine {
+	return &StateMachine{
+		InitialState: initialState,
+		States:       states,
+		cond:         sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (s *StateMachine) Current() StateName {
+	s.cond.L.Lock()
+	current := s.current
+	s.cond.L.Unlock()
+
+	if current == "" {
+		current = s.InitialState
+	}
+
+	return current
+}
+
+func (s *StateMachine) String() string {
+	return string(s.Current())
+}
+
+func (s *StateMachine) Transition(event EventName) (StateName, error) {
+	current := s.Current()
+
+	transitions := s.States[current].Events
+	transition, ok := transitions[event]
+	if !ok {
+		return "", errors.New("Invalid transition: Event not available for current state")
+	}
+
+	if transition.NewState != "" {
+		s.cond.L.Lock()
+		s.current = transition.NewState
+		s.cond.Broadcast()
+		s.cond.L.Unlock()
+	}
+
+	return s.Current(), nil
+}
+
+func (s *StateMachine) WaitFor(state StateName) {
+	s.cond.L.Lock()
+	for s.current != state {
+		s.cond.Wait()
+	}
+	s.cond.L.Unlock()
+	return
+}


### PR DESCRIPTION
Add missing endpoints to make tateru work.

Some points that might require more fixes/ discussion:

- The boot-installer request is not blocking/ not idempotent
- Handling of mutex unlock (defer is better than deadlocks in case of errors, but maybe we should use sync.Once?)
- Should we expire installRequests after some time?
- Should we implement an additional callback from the installer when it shuts down. Then we could clean up the installRequest.